### PR TITLE
fix: Set 'legendary_location_abandoned' flag

### DIFF
--- a/hreuniversalis/events/Fetishist.txt
+++ b/hreuniversalis/events/Fetishist.txt
@@ -4177,6 +4177,7 @@ country_event = {
 			name = tot_legend_abandoned
 			duration = 3650
 		}
+		set_country_flag = legendary_location_abandoned
 	}
 }
 


### PR DESCRIPTION
Again, not sure if you're willing to take PRs but it's something I ran into and figured I'd propose a fix for.

Without this flag set, the event will constantly recur throughout the game which clearly isn't the intention; nations should only be penalized once for abandoning the location.