### PR TITLE
nit: Land rights privilege order

### DIFF
--- a/hreuniversalis/common/estate_privileges/09_eunuchs_privileges.txt
+++ b/hreuniversalis/common/estate_privileges/09_eunuchs_privileges.txt
@@ -1,3 +1,39 @@
+estate_eunuchs_land_rights_privilege = {
+	icon = estate_eunuchs_land_rights_privilege
+	max_absolutism = -10
+	conditional_modifier = { trigger = { has_absolutism_reduction_for_estate_privileges = yes } modifier = { max_absolutism = 2 } }
+	land_share = 5
+	is_valid = { }
+	can_select = { }
+	influence = 0.05
+	loyalty = 0.05
+	benefits = { 
+		governing_capacity = 100 
+		min_autonomy = -5
+	}
+	penalties = {
+	}
+	conditional_modifier = {
+		trigger = { has_country_flag = mng_increased_land_rights_flag }
+		modifier = {
+			stability_cost_modifier = -0.05
+		}
+	}
+	modifier_by_land_ownership = { yearly_corruption = 0.15 } 
+	mechanics = { exempt_from_seize_land }
+	ai_will_do = {
+		factor = 1
+		modifier = { 
+			factor = 0.25 
+			NOT = { crown_land_share = 20 } 
+		}
+		modifier = {
+			factor = 0
+			yearly_corruption_increase = 0.35
+		}
+	}
+}
+
 estate_eunuchs_bookkeepers_privilege = {
 	icon = estate_eunuchs_bookkeepers_privilege
 	max_absolutism = -10
@@ -153,42 +189,6 @@ estate_eunuchs_imperial_council_privilege = {
 	}
 	ai_will_do = {
 		factor = 1
-		modifier = {
-			factor = 0
-			yearly_corruption_increase = 0.35
-		}
-	}
-}
-
-estate_eunuchs_land_rights_privilege = {
-	icon = estate_eunuchs_land_rights_privilege
-	max_absolutism = -10
-	conditional_modifier = { trigger = { has_absolutism_reduction_for_estate_privileges = yes } modifier = { max_absolutism = 2 } }
-	land_share = 5
-	is_valid = { }
-	can_select = { }
-	influence = 0.05
-	loyalty = 0.05
-	benefits = { 
-		governing_capacity = 100 
-		min_autonomy = -5
-	}
-	penalties = {
-	}
-	conditional_modifier = {
-		trigger = { has_country_flag = mng_increased_land_rights_flag }
-		modifier = {
-			stability_cost_modifier = -0.05
-		}
-	}
-	modifier_by_land_ownership = { yearly_corruption = 0.15 } 
-	mechanics = { exempt_from_seize_land }
-	ai_will_do = {
-		factor = 1
-		modifier = { 
-			factor = 0.25 
-			NOT = { crown_land_share = 20 } 
-		}
 		modifier = {
 			factor = 0
 			yearly_corruption_increase = 0.35

--- a/hreuniversalis/common/estate_privileges/VN_Holy_Orders_privileges.txt
+++ b/hreuniversalis/common/estate_privileges/VN_Holy_Orders_privileges.txt
@@ -1,84 +1,3 @@
-estate_holy_orders_liberties = {
-	icon = privilege_royal_authority
-	max_absolutism = -10
-	conditional_modifier = { trigger = { has_absolutism_reduction_for_estate_privileges = yes } modifier = { max_absolutism = 1 } }
-	influence = 0.1
-	loyalty = 0.1
-	is_valid = {
-	}
-	penalties = {
-	}
-	benefits = {
-	}
-	ai_will_do = {
-		factor = 1
-	}
-}
-
-estate_holy_orders_indebted_to_holy_orders = {
-	icon = privilege_give_money
-	max_absolutism = -5
-	conditional_modifier = { trigger = { has_absolutism_reduction_for_estate_privileges = yes } modifier = { max_absolutism = 1 } }
-	loyalty = 0.05
-	influence = 0.05
-	on_granted = {
-		custom_tooltip = estate_burghers_indebted_to_burghers_effect_tooltip
-		if = {
-			limit = { NOT = { has_government_attribute = no_mercantilism_loss_from_privilege } }
-			add_mercantilism = -1
-		}
-		tooltip = {
-			add_inflation = 0.5
-		}
-		hidden_effect = {
-			add_loan = {
-				fixed_interest = 1
-				duration = 60
-				estate_loan = yes
-			}
-			add_loan = {
-				fixed_interest = 1
-				duration = 60
-				estate_loan = yes
-			}
-			add_loan = {
-				fixed_interest = 1
-				duration = 60
-				estate_loan = yes
-			}
-			add_loan = {
-				fixed_interest = 1
-				duration = 60
-				estate_loan = yes
-			}
-			add_loan = {
-				fixed_interest = 1
-				duration = 60
-				estate_loan = yes
-			}
-		}
-	}
-	penalties = {
-		production_efficiency = -0.05
-	}
-	benefits = {
-	}
-	can_select = {
-		if = {
-			limit = {
-				has_estate_privilege = estate_holy_orders_indebted_to_holy_orders
-			}
-			has_estate_loan = yes
-		}
-	}
-	can_revoke = {
-		has_estate_loan = no
-	}
-	ai_will_do = {
-		factor = 0
-	}
-}
-
 estate_holy_orders_land_rights = {
 	icon = privilege_grant_autonomy
 	land_share = 5
@@ -273,6 +192,87 @@ estate_holy_orders_land_rights = {
 			factor = 0.75
 			has_estate_privilege = estate_mamluks_land_rights
 		}
+	}
+}
+
+estate_holy_orders_liberties = {
+	icon = privilege_royal_authority
+	max_absolutism = -10
+	conditional_modifier = { trigger = { has_absolutism_reduction_for_estate_privileges = yes } modifier = { max_absolutism = 1 } }
+	influence = 0.1
+	loyalty = 0.1
+	is_valid = {
+	}
+	penalties = {
+	}
+	benefits = {
+	}
+	ai_will_do = {
+		factor = 1
+	}
+}
+
+estate_holy_orders_indebted_to_holy_orders = {
+	icon = privilege_give_money
+	max_absolutism = -5
+	conditional_modifier = { trigger = { has_absolutism_reduction_for_estate_privileges = yes } modifier = { max_absolutism = 1 } }
+	loyalty = 0.05
+	influence = 0.05
+	on_granted = {
+		custom_tooltip = estate_burghers_indebted_to_burghers_effect_tooltip
+		if = {
+			limit = { NOT = { has_government_attribute = no_mercantilism_loss_from_privilege } }
+			add_mercantilism = -1
+		}
+		tooltip = {
+			add_inflation = 0.5
+		}
+		hidden_effect = {
+			add_loan = {
+				fixed_interest = 1
+				duration = 60
+				estate_loan = yes
+			}
+			add_loan = {
+				fixed_interest = 1
+				duration = 60
+				estate_loan = yes
+			}
+			add_loan = {
+				fixed_interest = 1
+				duration = 60
+				estate_loan = yes
+			}
+			add_loan = {
+				fixed_interest = 1
+				duration = 60
+				estate_loan = yes
+			}
+			add_loan = {
+				fixed_interest = 1
+				duration = 60
+				estate_loan = yes
+			}
+		}
+	}
+	penalties = {
+		production_efficiency = -0.05
+	}
+	benefits = {
+	}
+	can_select = {
+		if = {
+			limit = {
+				has_estate_privilege = estate_holy_orders_indebted_to_holy_orders
+			}
+			has_estate_loan = yes
+		}
+	}
+	can_revoke = {
+		has_estate_loan = no
+	}
+	ai_will_do = {
+		factor = 0
 	}
 }
 


### PR DESCRIPTION
Purely cosmetic & super nit-picky, but something I noticed is that when privileges are added, the icons from the estate view seem to be in order of their appearance in this list (not super familiar w/ EU4 modding, all my experience comes from grep + trial and error).

The holy orders & enuchs are the odd ones out here, every other estate with the land rights privilege lists it first which means that if the player were to enable all land rights privileges, they'd all align in the first column _except_ these two estates, which can end up in the second or third columns instead.

Git's choice of diff for the holy orders file is a bit weird, moving the first two privileges down rather than land rights up, but that's all it's doing.