### PR TITLE
fix: Correct cb for 'external_imperial_union' incident event

### DIFF
--- a/hreuniversalis/events/Incident_External_Imperial_Union.txt
+++ b/hreuniversalis/events/Incident_External_Imperial_Union.txt
@@ -145,7 +145,7 @@ country_event = {
 		add_prestige = 15
 		add_imperial_influence = 5
 		declare_war_with_cb = {
-			casus_belli = cb_imperial_ban
+			casus_belli = cb_imperial_ban_incident
 			who = event_target:pu_hre_country
 		}
 	}


### PR DESCRIPTION
Very far from 100% sure on this, there might be a different fix needed.

From my playing/testing, it seems as though this current CB (or something with the underlying event) doesn't quite work as intended. If the emperor picks this option they'll get a popup saying they've received the 'Imperial Ban' CB on the junior partner but no war will actually break out IME. This, as far as I can tell, is an unusable CB as they're a junior partner.

As I was debugging this I noticed the `_incident` variation of the CB, blindly tried it, and it seemed to fix the issue. There doesn't seem to be an obvious difference between the two CBs or the war goals they link to so I'm not quite sure why this is, but it does seem to work.

I ended up manually triggering the event again on a different suitable nation, to see if there was some unrelated problem with the original event that preceded the incident, but it did reproduce in the same way which makes me think it is indeed an issue with the CB? I very well could be wrong though.