### PR TITLE
fix: Revert 'coehorn-mortar' pips to vanilla

### DIFF
--- a/hreuniversalis/common/units/coehorn_mortar.txt
+++ b/hreuniversalis/common/units/coehorn_mortar.txt
@@ -3,10 +3,10 @@
 type = artillery
 
 maneuver = 2
-offensive_morale = 4
-defensive_morale = 2
-offensive_fire = 3
-defensive_fire = 3
+offensive_morale = 2
+defensive_morale = 3
+offensive_fire = 2
+defensive_fire = 4
 offensive_shock = 1
-defensive_shock = 1
+defensive_shock = 2
 


### PR DESCRIPTION
Super minor, but the "Coehorn Mortar" and "Horse Artillery" artillery units, unlocked together at tech 58, have the exact same pips in this mod at the moment. I imagine this isn't intentional, so I've corrected this by copying vanilla's pips for the "Coehorn Mortar" (the "Horse Artillery" already matches the vanilla pips).

Mix up might've stemmed from this comment, which is also in the vanilla files funnily enough:

https://github.com/Karrjaga/Voltaires-Dream/blob/056fa9e3a67fd13cf6240cebc0eecc6e1ed5db42/hreuniversalis/common/units/horse_artillery_unit.txt#L1-L2

I imagine this mistake was also in the vanilla game at some point, but perhaps they noticed and altered the pips (but not the comment)? Not sure, doesn't matter much anyhow.