### PR TITLE
fix: Ensure 'Poor Quality Copper' event is limited to correct mil tech

### DIFF
--- a/hreuniversalis/events/RandomEvents.txt
+++ b/hreuniversalis/events/RandomEvents.txt
@@ -12128,7 +12128,7 @@ country_event = {
 
 	trigger = {
 		copper = 1
-		mil_tech = 7
+		mil_tech = 40
 		NOT = { has_country_modifier = poor_copper }
 	}
 


### PR DESCRIPTION
Mil tech 7 in the base game is "The Limber", where the first artillery units are unlocked. The equivalent in the mod is 40.

Not much of an issue of course, just an increased cost for something players can't even get yet is all. Silly at most, won't negatively affect anyone.