### PR TITLE
fix: Correct Riga province ID for 'Confirm Thalassocracy' decision

### DIFF
--- a/hreuniversalis/decisions/Venice.txt
+++ b/hreuniversalis/decisions/Venice.txt
@@ -34,7 +34,7 @@ confirm_thalassocracy = {
 				1335 = { # Hamburg
 					is_strongest_trade_power = ROOT
 				}
-				712 = { # Riga
+				5793 = { # Riga
 					is_strongest_trade_power = ROOT
 				}
 			}
@@ -76,7 +76,7 @@ confirm_thalassocracy = {
 					1335 = { #Hamburg
 						is_strongest_trade_power = ROOT
 					}
-					712 = { #Riga
+					5793 = { #Riga
 						is_strongest_trade_power = ROOT
 					}
 				}


### PR DESCRIPTION
Province 712 is near Belgrade, in the Szeged trade node.